### PR TITLE
Fixed stopping strings

### DIFF
--- a/generate.py
+++ b/generate.py
@@ -30,10 +30,11 @@ async def generate_prompt_response(message, character, context):
         "min_tokens": user_settings["min_length"],
         "repetition_penalty": user_settings["repetition_penalty"],
         "stopping_strings": [f"{message.author.display_name}:"],
+        "stop": [f"{message.author.display_name}:"],
         "max_context_length": 8192,
     }
-    response = requests.post(API_ENDPOINT, headers=headers, json=data)
     print(f"Incoming message from {message.author.display_name}")
+    response = requests.post(API_ENDPOINT, headers=headers, json=data)
     print(f"Response Status Code: {response.status_code}")  # Print status code
     
     response_json = response.json()


### PR DESCRIPTION
After looking at the API documentation I think it's supposed to be "stop" for the stopping strings now. I've kept both in since it doesn't seem to hurt anything, but at some point I'll need to revisit this. Hopefully this also will solve the issue encountered in https://github.com/AICatgirls/aichatgirls/issues/15